### PR TITLE
Fixes image not deselected bug

### DIFF
--- a/imagepicker/src/main/java/com/nguyenhoanglam/imagepicker/adapter/ImagePickerAdapter.java
+++ b/imagepicker/src/main/java/com/nguyenhoanglam/imagepicker/adapter/ImagePickerAdapter.java
@@ -110,7 +110,14 @@ public class ImagePickerAdapter extends BaseRecyclerViewAdapter<ImagePickerAdapt
     }
 
     public void removeSelected(Image image, int position) {
-        selectedImages.remove(image);
+        Iterator<Image> itr = selectedImages.iterator();
+        while (itr.hasNext()) {
+            Image itrImage = itr.next();
+            if (itrImage.getId() == image.getId()) {
+                itr.remove();
+                break;
+            }
+        }
         notifyItemChanged(position);
         notifySelectionChanged();
     }


### PR DESCRIPTION
Image cannot be deselected after ImagePicker reopens the second time in Multimode.

Steps to reproduce the bug:
1. ImagePicker set to multimode.
2. Opens ImagePicker choose a few photos.
3. Click done and ImagePicker closes.
4. Opens ImagePicker again.
5. Attemp to deselect the selected pictures.
6. Pictures will not be deselected.